### PR TITLE
Sidebar active item

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,7 @@ export interface MyAppContext {
     sidebarIsOpen: boolean;
     notifications: boolean;
     activeDashboardPath: string | undefined;
+    activeDashboardMenus: Map<string, number>;
     access: boolean;
     redirect: string | undefined;
     userID: string | undefined;

--- a/src/components/global/Sidebar/Sidebar.scss
+++ b/src/components/global/Sidebar/Sidebar.scss
@@ -43,19 +43,11 @@ $transitionTime: 0.2s;
   width: 0;
   transition: width $transitionTime ease-in-out;
   padding: 0 0 0 0;
-  height: 100%;
+  bottom: 0;
   overflow-x: hidden;
-  overflow-y: hidden;
+  overflow-y: auto;
   background-color: white;
   border-right: 1px solid #e8e8e8;
-
-  &:hover {
-    overflow-y: auto;
-  }
-
-  &:focus {
-    overflow-y: auto;
-  }
 
   &.open {
     width: $sidebar-width;

--- a/src/components/global/Sidebar/Sidebar.scss
+++ b/src/components/global/Sidebar/Sidebar.scss
@@ -53,9 +53,10 @@ $transitionTime: 0.2s;
   }
 
   .scroll-content {
-    width: 100%;
+    height: 100%;
+    width: $sidebar-width - 16;
     overflow: visible;
-    box-sizing: border-box;
+    box-sizing: content-box;
     border-right: 1px solid #e8e8e8;
   }
 
@@ -72,13 +73,14 @@ $transitionTime: 0.2s;
   }
 
   .menu-primary {
-    box-sizing: border-box;
+    box-sizing: content-box;
     visibility: visible;
     font-family: "Light", sans-serif;
     font-size: 16px;
     color: $light-gray;
     list-style: none;
     width: inherit;
+    border-right: 1px solid #e8e8e8;
 
     li {
       cursor: pointer;

--- a/src/components/global/Sidebar/Sidebar.scss
+++ b/src/components/global/Sidebar/Sidebar.scss
@@ -47,13 +47,21 @@ $transitionTime: 0.2s;
   overflow-x: hidden;
   overflow-y: auto;
   background-color: white;
-  border-right: 1px solid #e8e8e8;
 
   &.open {
     width: $sidebar-width;
   }
 
+  .scroll-content {
+    width: 100%;
+    overflow: visible;
+    box-sizing: border-box;
+    border-right: 1px solid #e8e8e8;
+  }
+
   .close-button {
+    box-sizing: border-box;
+    width: inherit;
     display: flex;
     justify-content: flex-end;
 
@@ -64,6 +72,7 @@ $transitionTime: 0.2s;
   }
 
   .menu-primary {
+    box-sizing: border-box;
     visibility: visible;
     font-family: "Light", sans-serif;
     font-size: 16px;

--- a/src/components/global/Sidebar/Sidebar.stories.tsx
+++ b/src/components/global/Sidebar/Sidebar.stories.tsx
@@ -75,6 +75,7 @@ export const DefaultSidebar = () => (
     menuItems={mainItemsData}
     accountMenuItems={accountItemsData}
     isOpen={boolean("Visible?", true, "Toggles")}
+    activePath={undefined}
     {...actionsData}
   ></Sidebar>
 );
@@ -84,6 +85,7 @@ export const MissingIcon = () => (
     menuItems={missingIconData}
     accountMenuItems={accountItemsData}
     isOpen={boolean("Visible?", true, "Toggles")}
+    activePath={undefined}
     {...actionsData}
   ></Sidebar>
 );
@@ -93,6 +95,7 @@ export const CloseButtonOnSmallScreen = () => (
     menuItems={missingIconData}
     accountMenuItems={accountItemsData}
     isOpen={boolean("Visible?", true, "Toggles")}
+    activePath={undefined}
     {...actionsData}
   ></Sidebar>
 );

--- a/src/components/global/Sidebar/Sidebar.tsx
+++ b/src/components/global/Sidebar/Sidebar.tsx
@@ -72,6 +72,9 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
     // call props onNavigate function with route path
     // only call if there is no submenu
     if (!item.subItems) {
+      context.setContextProperty({
+        activeDashboardMenus: activeSubMenus,
+      });
       props.onNavigate(item.path);
     }
   };

--- a/src/components/global/Sidebar/Sidebar.tsx
+++ b/src/components/global/Sidebar/Sidebar.tsx
@@ -156,19 +156,21 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
       <div
         className={`sidebar-panel ${context.sidebarIsOpen ? "open" : ""}`}
         style={{top: scrollTop}}>
-        <div className="close-button">
-          <span
-            uk-icon="icon: close; ratio: 1.2"
-            onClick={() => handleCloseSidebar()}
-          ></span>
-        </div>
-        <ul
-          className="uk-nav menu-primary">
-          {navLinks}
+        <div className="scroll-content">
+          <div className="close-button">
+            <span
+              uk-icon="icon: close; ratio: 1.2"
+              onClick={() => handleCloseSidebar()}
+            ></span>
+          </div>
+          <ul
+            className="uk-nav menu-primary">
+            {navLinks}
 
-          <div className="section-title">Account</div>
-          {accountLinks}
-        </ul>
+            <div className="section-title">Account</div>
+            {accountLinks}
+          </ul>
+        </div>
       </div>
 
     </aside>

--- a/src/components/global/Sidebar/Sidebar.tsx
+++ b/src/components/global/Sidebar/Sidebar.tsx
@@ -19,6 +19,7 @@ interface SidebarProps {
   menuItems: SidebarItem[];
   accountMenuItems: SidebarItem[];
   isOpen: boolean;
+  activePath: string | undefined;
   onNavigate: (path: string) => void;
 }
 
@@ -27,10 +28,8 @@ type ActiveSubMenus = Map<string, number>;
 
 const Sidebar: React.FC<SidebarProps> = (props) => {
   const context = useContext(Context);
-
   // state for clicked (active) and hovered (mouse hover to show submenu)
   // dashboard links
-  const [activeItemLabel, setActiveItemLabel] = React.useState<string>("");
   const [activeSubMenus, setActiveSubMenus] = React.useState<ActiveSubMenus>(new Map());
   const [scrollTop, setScrollTop] = React.useState<number>(80);
 
@@ -71,8 +70,6 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
     if (!item.subItems) {
       props.onNavigate(item.path);
     }
-    // set main item active styles
-    setActiveItemLabel(item.label);
   };
 
   const handleSubMenuItemClicked = (path: string) => {
@@ -93,7 +90,7 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
       }
 
       // for primary menu (top level items)
-      const isActiveItem = activeItemLabel === item.label;
+      const isActiveItem = props.activePath?.split("/")[1] === item.path.split("/")[1];
       const subMenuHeight = activeSubMenus.get(item.label);
       const hasSubMenu = subMenuHeight ? true : false;
 

--- a/src/components/global/Sidebar/Sidebar.tsx
+++ b/src/components/global/Sidebar/Sidebar.tsx
@@ -30,7 +30,11 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
   const context = useContext(Context);
   // state for clicked (active) and hovered (mouse hover to show submenu)
   // dashboard links
-  const [activeSubMenus, setActiveSubMenus] = React.useState<ActiveSubMenus>(new Map());
+
+  // initialize active submenu items from context
+  const [activeSubMenus, setActiveSubMenus] = React.useState<ActiveSubMenus>(context.activeDashboardMenus);
+
+  // TODO - using fixed 80 px navbar. Allow accessing from prop
   const [scrollTop, setScrollTop] = React.useState<number>(80);
 
   const handleScroll = () => {
@@ -73,6 +77,11 @@ const Sidebar: React.FC<SidebarProps> = (props) => {
   };
 
   const handleSubMenuItemClicked = (path: string) => {
+    // store the expanded menus in context
+    context.setContextProperty({
+      activeDashboardMenus: activeSubMenus,
+    });
+    // call function in parent to navigate
     props.onNavigate(path);
   };
 

--- a/src/components/global/Sidebar/usage.md
+++ b/src/components/global/Sidebar/usage.md
@@ -31,6 +31,9 @@ This accepts the same properties as menu items. However, the these items will be
 
 A boolean value used to toggle the [Off-canvas](https://getuikit.com/docs/offcanvas) visibility. This allows the menu visibility to be controlled (for example on mobile)
 
+#### activePath
+Will be used to keep the active parent item path highlighted. Submenu items are not highlighted.
+
 
 #### onNavigate
 

--- a/src/components/layouts/DashboardLayout.tsx
+++ b/src/components/layouts/DashboardLayout.tsx
@@ -48,7 +48,12 @@ const Dashboard: React.FC = function(props) {
       {/* // TODO: Need to make it so we just need to call <Sidebar> - low priority. */}
 
       <div id="dashboard-container" className="uk-flex">
-        <Sidebar accountMenuItems={account} menuItems={main} isOpen={sidebarIsOpen} onNavigate={(path) => onNavigate(path)} />
+        <Sidebar
+          accountMenuItems={account}
+          menuItems={main}
+          isOpen={sidebarIsOpen}
+          activePath={context.activeDashboardPath}
+          onNavigate={(path) => onNavigate(path)} />
 
         <div id="panel-container" >
           {menuToggleIcon}

--- a/src/context.ts
+++ b/src/context.ts
@@ -28,8 +28,6 @@ export const SidebarOptions = {
     ]},
     {icon: "far fa-sign-out", label: "Logout", path: "/logout"},
   ],
-  open: true,
-  active: "/dashboard",
 };
 
 export const defaultContext = {
@@ -39,6 +37,7 @@ export const defaultContext = {
   notifications: true,
   isAccessFetched: false,
   activeDashboardPath: "dasboard",
+  activeDashboardMenus: new Map(),
   access: false,
   redirect: undefined,
   isPublic: false,


### PR DESCRIPTION
@saynegrojas, could you take a look at the sidebar updates?

I made the parent-level item stay highlighted and the children items stay expanded on navigation.

There are a few other problems I am considering fixing. Do you have an opinion?

1. I can't stand the scroll bar overlay on the border, though this may not be fixable as it's very browser dependent. See image below.
![Screen Shot 2020-03-02 at 2 44 26 PM](https://user-images.githubusercontent.com/8978605/75725162-c3e98e00-5c94-11ea-8c0a-8cf91dca55d9.png)
2. I would like to default to closing the sidebar when navigating on mobile. What do you think?